### PR TITLE
fix(glow-capture): check parent template ref when unmounting

### DIFF
--- a/src/runtime/components/GlowCapture.vue
+++ b/src/runtime/components/GlowCapture.vue
@@ -51,6 +51,9 @@ export default {
     });
 
     onUnmounted(() => {
+      if (!elementParent.value) {
+        return;
+      }
       elementParent.value.removeEventListener("pointermove", move);
       elementParent.value.removeEventListener("pointerleave", leave);
     });


### PR DESCRIPTION
First of all, I want to thank you for this really cool plugin, keep the good work ❤️ ! However, I found a little problem using it.

## 👽 The problem

The plugin works pretty good but it faces an issue when you unmount the `<GlowCapture>` component. It happened when one of my component using a `GlowCapture` was unmounted. In my case, my component is rendered with a `v-if`. I had the following error when the `v-if` condition of my component is set to `false` : 
```typescript
Uncaught (in promise) TypeError: Cannot read properties of null (reading 'removeEventListener')
```

It happens in the `GlowCapture` component, in the `onUnmount` hook :

```typescript
onUnmounted(()=>{
    elementParent.value.removeEventListener("pointermove", move); // <-- elementParent.value is null
    elementParent.value.removeEventListener("pointerleave", leave);
}
```

## 💎 The solution

I just added an early return if the `elementParent.value` is `undefined` or `null`. That way, it prevents the error.

---

I hope you find this fix useful. Let me know if something must be changed in my PR.